### PR TITLE
Bazel tooling for compile_commands.json

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,9 @@ build:macos --host_cxxopt=-std=c++14
 # the project separately.
 build --experimental_convenience_symlinks=ignore
 
+# Generate compile_commands.json for tools that require it.
+run:compile-commands --experimental_convenience_symlinks=normal @hedron_compile_commands//:refresh_all
+
 # We mirror critical tarballs from several sources in case the canonical source
 # is temporarily unavailable, e.g., github.com being down. This option and flag
 # automatically rewrites the URLs.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -86,3 +86,11 @@ git_repository(
     commit = "496018e020cf0a7d813a2b5a9d246ec55340a7ed",
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )
+
+# FIXME: switch to hedronvision/bazel-compile-commands-extractor once https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219 lands
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/mikael-s-persson/bazel-compile-commands-extractor.git",
+    commit = "02d15621b528efd877f5d5657c4b738523a0eb17",
+)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ bigtable-emulator -p <port>
 clang-format -i -style=file -assume-filename=.clang-format **/*.cc **/*.h
 ```
 
+### `compile_commands.json`
+If you need to generate `compile_commands.json` for your tooling, run:
+```shell
+bazel run --config=compile-commands
+```
+
 ## Contributing changes
 
 See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to contribute to


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/bigtable-emulator/6)
<!-- Reviewable:end -->

It's possibly mergable only after https://github.com/hedronvision/bazel-compile-commands-extractor/pull/219 lands

edit: Note that protobuf-generated code remains a problem (for both development using compile_commands.json and clang-tidy) - by default it's compiled into .o files with .pb.h  and .pb.cc are deleted.