### PR TITLE
Run clang-tidy with Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -131,3 +131,8 @@ build:msan --linkopt=-L/usr/lib/x86_64-unknown-linux-gnu
 
 # --config otel2: Open Telemetery ABI version 2
 # build:otel2 --cxxopt=-DOPENTELEMETRY_ABI_VERSION_NO=2
+
+# --config clang-tidy: clang-tidy
+build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+build:clang-tidy --output_groups=report

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -87,7 +87,6 @@ Checks: >
   readability-*,
   -google-readability-braces-around-statements,
   -google-readability-namespace-comments,
-  -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -misc-const-correctness,
   -misc-include-cleaner,
@@ -138,8 +137,8 @@ CheckOptions:
   - { key: readability-identifier-naming.ConstexprVariablePrefix,  value: k         }
   - { key: readability-identifier-naming.GlobalConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.GlobalConstantPrefix,     value: k         }
-  - { key: readability-identifier-naming.MemberConstantCase,       value: CamelCase }
-  - { key: readability-identifier-naming.MemberConstantPrefix,     value: k         }
+  - { key: readability-identifier-naming.ClassConstantCase,       value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantPrefix,     value: k         }
   - { key: readability-identifier-naming.StaticConstantCase,       value: CamelCase }
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -58,3 +58,9 @@ gen_cc_tests(
         "@google_cloud_cpp//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
 )
+
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [".clang-tidy"],
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -80,3 +80,9 @@ git_repository(
     patches = ["//bazel:google_cloud_cpp.patch"],
     patch_args = ["-p1"],
 )
+
+git_repository(
+    name = "bazel_clang_tidy",
+    commit = "496018e020cf0a7d813a2b5a9d246ec55340a7ed",
+    remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ production Bigtable.
 Building the Bigtable emulator requires `bazel`.
 
 ```shell
-cd bigtable-emulator
-bazel build ...
+bazel build //...
 ```
+
 ## Running the Unit Tests
 
 ```shell
-bazel test ...
+bazel test //...
 ```
 
 ## Running clang-tidy with Bazel
@@ -26,10 +26,18 @@ bazel test ...
 bazel build --config clang-tidy //...
 ```
 
-### Running the Emulator
+## Running the Emulator
 
 ```shell
 bigtable-emulator -p <port>
+```
+
+## Development
+
+### Formatting the code
+```bash
+# On bash you neet to enable globstar with `shopt -s globstar` first
+clang-format -i -style=file -assume-filename=.clang-format **/*.cc **/*.h
 ```
 
 ## Contributing changes

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ bazel build ...
 bazel test ...
 ```
 
+## Running clang-tidy with Bazel
+
+```shell
+bazel build --config clang-tidy //...
+```
+
 ### Running the Emulator
 
 ```shell


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unoperate/bigtable-emulator/8)
<!-- Reviewable:end -->

I tried to make `clang-tidy` work directly, but I failed to prevent Bazel from removing `.pb.h` and `.pb.cc` files generated during the build, which made `compile_commands.json` generated with https://github.com/Unoperate/bigtable-emulator/pull/6 point to nonexistent paths.
If I took a few more hours maybe I'd succeed.

On the other hand, this off-the-shelf solution works well and even caches the results, which is really nice in my experience.